### PR TITLE
feat: 로그인 기능 구현#37

### DIFF
--- a/Backend/build.gradle.kts
+++ b/Backend/build.gradle.kts
@@ -47,6 +47,17 @@ dependencies {
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     testImplementation ("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+
+    // ✅ SpringSecurity (Jakarta)
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // ✅ jjwt
+    implementation("io.jsonwebtoken:jjwt-api:0.13.0")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.13.0")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.13.0")
 }
 
 

--- a/Backend/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/Backend/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -1,0 +1,125 @@
+package com.back.domain.member.member.controller;
+
+import com.back.domain.member.member.dto.MemberDto;
+import com.back.domain.member.member.dto.MemberWithUsernameDto;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberService;
+import com.back.global.exception.ServiceException;
+import com.back.global.rq.Rq;
+import com.back.global.rsData.RsData;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+    private final Rq rq;
+
+
+    record MemberJoinReqBody(
+            @NotBlank
+            @Size(min = 2, max = 30)
+            String username,
+            @NotBlank
+            @Size(min = 2, max = 30)
+            String password,
+            @NotBlank
+            @Size(min = 2, max = 30)
+            String nickname
+    ) {
+    }
+
+    @PostMapping
+    @Transactional
+    public RsData<MemberDto> join(
+            @Valid @RequestBody MemberJoinReqBody reqBody
+    ) {
+        Member member = memberService.join(
+                reqBody.username(),
+                reqBody.password(),
+                reqBody.nickname()
+        );
+
+        return new RsData<>(
+                "201-1",
+                "%s님 환영합니다. 회원가입이 완료되었습니다.".formatted(member.getName()),
+                new MemberDto(member)
+        );
+    }
+
+
+    record MemberLoginReqBody(
+            @NotBlank
+            @Size(min = 2, max = 30)
+            String username,
+            @NotBlank
+            @Size(min = 2, max = 30)
+            String password
+    ) {
+    }
+
+    record MemberLoginResBody(
+            MemberDto item,
+            String apiKey,
+            String accessToken
+    ) {
+    }
+
+    @PostMapping("/login")
+    @Transactional(readOnly = true)
+    public RsData<MemberLoginResBody> login(
+            @Valid @RequestBody MemberLoginReqBody reqBody
+    ) {
+        Member member = memberService.findByUsername(reqBody.username())
+                .orElseThrow(() -> new ServiceException("401-1", "존재하지 않는 아이디입니다."));
+
+        memberService.checkPassword(
+                member,
+                reqBody.password()
+        );
+
+        String accessToken = memberService.genAccessToken(member);
+
+        rq.setCookie("apiKey", member.getApiKey());
+        rq.setCookie("accessToken", accessToken);
+
+        return new RsData<>(
+                "200-1",
+                "%s님 환영합니다.".formatted(member.getName()),
+                new MemberLoginResBody(
+                        new MemberDto(member),
+                        member.getApiKey(),
+                        accessToken
+                )
+        );
+    }
+
+
+    @DeleteMapping("/logout")
+    public RsData<Void> logout() {
+        rq.deleteCookie("apiKey");
+        rq.deleteCookie("accessToken");
+
+        return new RsData<>(
+                "200-1",
+                "로그아웃 되었습니다."
+        );
+    }
+
+
+    @GetMapping("/me")
+    @Transactional(readOnly = true)
+    public MemberWithUsernameDto me() {
+        Member actor = memberService
+                .findById(rq.getActor().getId())
+                .get();
+
+        return new MemberWithUsernameDto(actor);
+    }
+}

--- a/Backend/src/main/java/com/back/domain/member/member/dto/MemberDto.java
+++ b/Backend/src/main/java/com/back/domain/member/member/dto/MemberDto.java
@@ -1,0 +1,28 @@
+package com.back.domain.member.member.dto;
+
+import com.back.domain.member.member.entity.Member;
+
+import java.time.LocalDateTime;
+
+public record MemberDto(
+        long id,
+        LocalDateTime createDate,
+        LocalDateTime modifyDate,
+        String name
+) {
+    public MemberDto(long id, LocalDateTime createDate, LocalDateTime modifyDate, String name) {
+        this.id = id;
+        this.createDate = createDate;
+        this.modifyDate = modifyDate;
+        this.name = name;
+    }
+
+    public MemberDto(Member member) {
+        this(
+                member.getId(),
+                member.getCreateDate(),
+                member.getModifyDate(),
+                member.getName()
+        );
+    }
+}

--- a/Backend/src/main/java/com/back/domain/member/member/dto/MemberWithUsernameDto.java
+++ b/Backend/src/main/java/com/back/domain/member/member/dto/MemberWithUsernameDto.java
@@ -1,0 +1,31 @@
+package com.back.domain.member.member.dto;
+
+import com.back.domain.member.member.entity.Member;
+
+import java.time.LocalDateTime;
+
+public record MemberWithUsernameDto(
+        long id,
+        LocalDateTime createDate,
+        LocalDateTime modifyDate,
+        String name,
+        String username
+) {
+    public MemberWithUsernameDto(long id, LocalDateTime createDate, LocalDateTime modifyDate, String name, String username) {
+        this.id = id;
+        this.createDate = createDate;
+        this.modifyDate = modifyDate;
+        this.name = name;
+        this.username = username;
+    }
+
+    public MemberWithUsernameDto(Member member) {
+        this(
+                member.getId(),
+                member.getCreateDate(),
+                member.getModifyDate(),
+                member.getName(),
+                member.getUsername()
+        );
+    }
+}

--- a/Backend/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/Backend/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -1,0 +1,74 @@
+package com.back.domain.member.member.entity;
+
+import com.back.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Member extends BaseEntity {
+    @Column(unique = true)
+    private String username;
+    private String password;
+    private String nickname;
+    @Column(unique = true)
+    private String apiKey;
+
+    public Member(long id, String username, String name) {
+        setId(id);
+        this.username = username;
+        setName(name);
+    }
+
+    public Member(String username, String password, String nickname) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+        this.apiKey = UUID.randomUUID().toString();
+    }
+
+    public String getName() {
+        return nickname;
+    }
+
+    public void setName(String name) {
+        this.nickname = name;
+    }
+
+    public void modifyApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public boolean isAdmin() {
+        if ("system".equals(username)) return true;
+        if ("admin".equals(username)) return true;
+
+        return false;
+    }
+
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return getAuthoritiesAsStringList()
+                .stream()
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+    }
+
+    private List<String> getAuthoritiesAsStringList() {
+        List<String> authorities = new ArrayList<>();
+
+        if (isAdmin())
+            authorities.add("ROLE_ADMIN");
+
+        return authorities;
+    }
+}

--- a/Backend/src/main/java/com/back/domain/member/member/repository/MemberRepository.java
+++ b/Backend/src/main/java/com/back/domain/member/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.back.domain.member.member.repository;
+
+import com.back.domain.member.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByUsername(String username);
+
+    Optional<Member> findByApiKey(String apiKey);
+}

--- a/Backend/src/main/java/com/back/domain/member/member/service/AuthTokenService.java
+++ b/Backend/src/main/java/com/back/domain/member/member/service/AuthTokenService.java
@@ -1,0 +1,42 @@
+package com.back.domain.member.member.service;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.standard.util.Ut;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+public class AuthTokenService {
+    @Value("${custom.jwt.secretKey}")
+    private String jwtSecretKey;
+
+    @Value("${custom.accessToken.expirationSeconds}")
+    private int accessTokenExpirationSeconds;
+
+    String genAccessToken(Member member) {
+        long id = member.getId();
+        String username = member.getUsername();
+        String name = member.getName();
+
+        return Ut.jwt.toString(
+                jwtSecretKey,
+                accessTokenExpirationSeconds,
+                Map.of("id", id, "username", username, "name", name)
+        );
+    }
+
+    Map<String, Object> payload(String accessToken) {
+        Map<String, Object> parsedPayload = Ut.jwt.payload(jwtSecretKey, accessToken);
+
+        if (parsedPayload == null) return null;
+
+        int id_ = (int) parsedPayload.get("id");
+        long id = (long) id_;
+        String username = (String) parsedPayload.get("username");
+        String name = (String) parsedPayload.get("name");
+
+        return Map.of("id", id, "username", username, "name", name);
+    }
+}

--- a/Backend/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/Backend/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -1,0 +1,67 @@
+package com.back.domain.member.member.service;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final AuthTokenService authTokenService;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public long count() {
+        return memberRepository.count();
+    }
+
+    public Member join(String username, String password, String nickname) {
+        memberRepository
+                .findByUsername(username)
+                .ifPresent(_member -> {
+                    throw new ServiceException("409-1", "이미 존재하는 아이디입니다.");
+                });
+
+        password = passwordEncoder.encode(password);
+
+        Member member = new Member(username, password, nickname);
+
+        return memberRepository.save(member);
+    }
+
+    public Optional<Member> findByUsername(String username) {
+        return memberRepository.findByUsername(username);
+    }
+
+    public Optional<Member> findByApiKey(String apiKey) {
+        return memberRepository.findByApiKey(apiKey);
+    }
+
+    public String genAccessToken(Member member) {
+        return authTokenService.genAccessToken(member);
+    }
+
+    public Map<String, Object> payload(String accessToken) {
+        return authTokenService.payload(accessToken);
+    }
+
+    public Optional<Member> findById(long id) {
+        return memberRepository.findById(id);
+    }
+
+    public List<Member> findAll() {
+        return memberRepository.findAll();
+    }
+
+    public void checkPassword(Member member, String password) {
+        if (!passwordEncoder.matches(password, member.getPassword()))
+            throw new ServiceException("401-1", "비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/Backend/src/main/java/com/back/global/config/AppConfig.java
+++ b/Backend/src/main/java/com/back/global/config/AppConfig.java
@@ -1,0 +1,56 @@
+package com.back.global.config;
+
+import com.back.standard.util.Ut;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AppConfig {
+    private static Environment environment;
+
+    @Autowired
+    public void setEnvironment(Environment environment) {
+        AppConfig.environment = environment;
+    }
+
+    public static boolean isDev() {
+        return environment.matchesProfiles("dev");
+    }
+
+    public static boolean isTest() {
+        return !environment.matchesProfiles("test");
+    }
+
+    public static boolean isProd() {
+        return environment.matchesProfiles("prod");
+    }
+
+    public static boolean isNotProd() {
+        return !isProd();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Getter
+    private static ObjectMapper objectMapper;
+
+    @Autowired
+    public void setObjectMapper(ObjectMapper objectMapper) {
+        AppConfig.objectMapper = objectMapper;
+    }
+
+    @PostConstruct
+    public void postConstruct() {
+        Ut.json.objectMapper = objectMapper;
+    }
+}

--- a/Backend/src/main/java/com/back/global/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/back/global/config/SecurityConfig.java
@@ -1,0 +1,106 @@
+package com.back.global.config;
+
+import com.back.global.rsData.RsData;
+import com.back.global.security.CustomAuthenticationFilter;
+import com.back.standard.util.Ut;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final CustomAuthenticationFilter customAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(
+                        auth -> auth
+                                .requestMatchers(
+                                        "/api/**"
+                                ).permitAll()
+                                .anyRequest().permitAll()
+                )
+                .headers(
+                        headers -> headers
+                                .frameOptions(
+                                        HeadersConfigurer.FrameOptionsConfig::sameOrigin
+                                )
+                )
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(AbstractHttpConfigurer::disable)
+                .addFilterBefore(customAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(
+                        exceptionHandling -> exceptionHandling
+                                .authenticationEntryPoint(
+                                        (request, response, authException) -> {
+                                            response.setContentType("application/json;charset=UTF-8");
+
+                                            response.setStatus(401);
+                                            response.getWriter().write(
+                                                    Ut.json.toString((
+                                                                    new RsData<Void>(
+                                                                            "401-1",
+                                                                            "로그인 후 이용해주세요."
+                                                                    )
+                                                            )
+                                                    )
+                                            );
+                                        }
+                                )
+                                .accessDeniedHandler(
+                                        (request, response, accessDeniedException) -> {
+                                            response.setContentType("application/json;charset=UTF-8");
+
+                                            response.setStatus(403);
+                                            response.getWriter().write(
+                                                    Ut.json.toString(
+                                                            new RsData<Void>(
+                                                                    "403-1",
+                                                                    "권한이 없습니다."
+                                                            )
+                                                    )
+                                            );
+                                        }
+                                )
+                );
+
+
+        return http.build();
+    }
+
+    @Bean
+    public UrlBasedCorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        // 허용할 오리진 설정
+        configuration.setAllowedOrigins(List.of("https://cdpn.io", "http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
+
+        // 자격 증명 허용 설정
+        configuration.setAllowCredentials(true);
+
+        // 허용할 헤더 설정
+        configuration.setAllowedHeaders(List.of("*"));
+
+        // CORS 설정을 소스에 등록
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", configuration);
+
+        return source;
+    }
+}

--- a/Backend/src/main/java/com/back/global/entity/BaseEntity.java
+++ b/Backend/src/main/java/com/back/global/entity/BaseEntity.java
@@ -2,6 +2,7 @@ package com.back.global.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 public class BaseEntity {
     @GeneratedValue
     @Id
+    @Setter
     private long id;
     @CreatedDate
     private LocalDateTime createDate;

--- a/Backend/src/main/java/com/back/global/exception/ServiceException.java
+++ b/Backend/src/main/java/com/back/global/exception/ServiceException.java
@@ -1,0 +1,18 @@
+package com.back.global.exception;
+
+import com.back.global.rsData.RsData;
+
+public class ServiceException extends RuntimeException {
+    private final String resultCode;
+    private final String msg;
+
+    public ServiceException(String resultCode, String msg) {
+        super(resultCode + " : " + msg);
+        this.resultCode = resultCode;
+        this.msg = msg;
+    }
+
+    public RsData<Void> getRsData() {
+        return new RsData<>(resultCode, msg, null);
+    }
+}

--- a/Backend/src/main/java/com/back/global/initData/BaseInitData.java
+++ b/Backend/src/main/java/com/back/global/initData/BaseInitData.java
@@ -1,8 +1,11 @@
 package com.back.global.initData;
 
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberService;
 import com.back.domain.post.post.entity.Post;
 import com.back.domain.post.post.entity.PostTag;
 import com.back.domain.post.post.service.PostService;
+import com.back.global.config.AppConfig;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,11 +24,13 @@ public class BaseInitData {
     @Lazy
     private BaseInitData self;
     private final PostService postService;
+    private final MemberService memberService;
 
     @Bean
     ApplicationRunner applicationRunner() {
         return args -> {
             self.work1();
+            self.work2();
         };
     }
 
@@ -45,5 +50,26 @@ public class BaseInitData {
         post2.addComment("댓글 2-1");
         post2.addComment("댓글 2-2");
     }
+
+    @Transactional
+    public void work2() {
+        if (memberService.count() > 0) return;
+
+        Member memberSystem = memberService.join("system", "1234", "시스템");
+        if (AppConfig.isNotProd()) memberSystem.modifyApiKey(memberSystem.getUsername());
+
+        Member memberAdmin = memberService.join("admin", "1234", "관리자");
+        if (AppConfig.isNotProd()) memberAdmin.modifyApiKey(memberAdmin.getUsername());
+
+        Member memberUser1 = memberService.join("user1", "1234", "유저1");
+        if (AppConfig.isNotProd()) memberUser1.modifyApiKey(memberUser1.getUsername());
+
+        Member memberUser2 = memberService.join("user2", "1234", "유저2");
+        if (AppConfig.isNotProd()) memberUser2.modifyApiKey(memberUser2.getUsername());
+
+        Member memberUser3 = memberService.join("user3", "1234", "유저3");
+        if (AppConfig.isNotProd()) memberUser3.modifyApiKey(memberUser3.getUsername());
+    }
+
 
 }

--- a/Backend/src/main/java/com/back/global/rq/Rq.java
+++ b/Backend/src/main/java/com/back/global/rq/Rq.java
@@ -1,0 +1,85 @@
+package com.back.global.rq;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.global.security.SecurityUser;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class Rq {
+    private final HttpServletRequest req;
+    private final HttpServletResponse resp;
+
+    public Member getActor() {
+        return Optional.ofNullable(
+                        SecurityContextHolder
+                                .getContext()
+                                .getAuthentication()
+                )
+                .map(Authentication::getPrincipal)
+                .filter(principal -> principal instanceof SecurityUser)
+                .map(principal -> (SecurityUser) principal)
+                .map(securityUser -> new Member(securityUser.getId(), securityUser.getUsername(), securityUser.getName()))
+                .orElse(null);
+    }
+
+    public String getHeader(String name, String defaultValue) {
+        return Optional
+                .ofNullable(req.getHeader(name))
+                .filter(headerValue -> !headerValue.isBlank())
+                .orElse(defaultValue);
+    }
+
+    public void setHeader(String name, String value) {
+        if (value == null) value = "";
+
+        if (value.isBlank()) {
+            req.removeAttribute(name);
+        } else {
+            resp.setHeader(name, value);
+        }
+    }
+
+    public String getCookieValue(String name, String defaultValue) {
+        return Optional
+                .ofNullable(req.getCookies())
+                .flatMap(
+                        cookies ->
+                                Arrays.stream(cookies)
+                                        .filter(cookie -> cookie.getName().equals(name))
+                                        .map(Cookie::getValue)
+                                        .filter(value -> !value.isBlank())
+                                        .findFirst()
+                )
+                .orElse(defaultValue);
+    }
+
+    public void setCookie(String name, String value) {
+        if (value == null) value = "";
+
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setDomain("localhost");
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "Strict");
+
+        if (value.isBlank()) cookie.setMaxAge(0);
+        else cookie.setMaxAge(60 * 60 * 24 * 365);
+
+        resp.addCookie(cookie);
+    }
+
+    public void deleteCookie(String name) {
+        setCookie(name, null);
+    }
+}

--- a/Backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/Backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -1,0 +1,153 @@
+package com.back.global.security;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberService;
+import com.back.global.exception.ServiceException;
+import com.back.global.rq.Rq;
+import com.back.global.rsData.RsData;
+import com.back.standard.util.Ut;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationFilter extends OncePerRequestFilter {
+    private final MemberService memberService;
+    private final Rq rq;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        logger.debug("Processing request for " + request.getRequestURI());
+
+        try {
+            work(request, response, filterChain);
+        } catch (ServiceException e) {
+            RsData<Void> rsData = e.getRsData();
+            response.setContentType("application/json");
+            response.setStatus(rsData.statusCode());
+            response.getWriter().write(
+                    Ut.json.toString(rsData)
+            );
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+    private void work(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // API 요청이 아니라면 패스
+        if (!request.getRequestURI().startsWith("/api/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 인증, 인가가 필요없는 API 요청이라면 패스
+        if (List.of("/api/v1/members/login", "/api/v1/members/logout", "/api/v1/members/join").contains(request.getRequestURI())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String apiKey;
+        String accessToken;
+
+        // 토큰 추출 로직 (헤더 -> 쿠키)
+        String headerAuthorization = rq.getHeader("Authorization", "");
+
+        // Authorization 헤더가 있는 경우
+        if (!headerAuthorization.isBlank()) {
+            if (!headerAuthorization.startsWith("Bearer "))
+                throw new ServiceException("401-2", "Authorization 헤더가 Bearer 형식이 아닙니다.");
+
+            String[] headerAuthorizationBits = headerAuthorization.split(" ", 3);
+
+            apiKey = headerAuthorizationBits[1];
+            accessToken = headerAuthorizationBits.length == 3 ? headerAuthorizationBits[2] : "";
+        } else {
+            // 헤더가 없으면 쿠키에서 조회
+            apiKey = rq.getCookieValue("apiKey", "");
+            accessToken = rq.getCookieValue("accessToken", "");
+        }
+
+        logger.debug("apiKey : " + apiKey);
+        logger.debug("accessToken : " + accessToken);
+
+        boolean isApiKeyExists = !apiKey.isBlank();
+        boolean isAccessTokenExists = !accessToken.isBlank();
+
+        // apiKey(리프레시 토큰) + 액세스 토큰 둘 다 없으면 패스
+        if (!isApiKeyExists && !isAccessTokenExists) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Member member = null;
+        boolean isAccessTokenValid = false;
+
+        // 액세스 토큰 검증
+        if (isAccessTokenExists) {
+            Map<String, Object> payload = memberService.payload(accessToken);
+
+            if (payload != null) {
+                int id = (int) payload.get("id");
+                String username = (String) payload.get("username");
+                String name = (String) payload.get("name");
+                member = new Member(id, username, name);
+
+                isAccessTokenValid = true;
+            }
+        }
+
+        // 액세스 토큰이 없거나 실패하면 apiKey로 사용자 인증
+        if (member == null) {
+            member = memberService
+                    .findByApiKey(apiKey)
+                    .orElseThrow(() -> new ServiceException("401-3", "API 키가 유효하지 않습니다."));
+        }
+
+        // 액세스 토큰은 있는데 기간이 만료되었다면(유효하지 않다면) 재발급
+        if (isAccessTokenExists && !isAccessTokenValid) {
+            // 액세스 토큰 생성
+            String actorAccessToken = memberService.genAccessToken(member);
+
+            // 액세스 토큰을 쿠키와 헤더에 저장
+            rq.setCookie("accessToken", actorAccessToken);
+            rq.setHeader("Authorization", actorAccessToken);
+        }
+
+        // Spring Security 인증 객체 생성 ⭐
+        UserDetails user = new SecurityUser(
+                member.getId(),
+                member.getUsername(),
+                "",
+                member.getName(),
+                member.getAuthorities()
+        );
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                user,
+                user.getPassword(),
+                user.getAuthorities()
+        );
+
+        // 인증 완료 처리
+        // 이 시점 이후부터는 시큐리티가 이 요청을 인증된 사용자의 요청이다.
+        SecurityContextHolder
+                .getContext()
+                .setAuthentication(authentication);
+
+        // 다음 필터로 넘김
+        filterChain.doFilter(request, response);
+    }
+}

--- a/Backend/src/main/java/com/back/global/security/CustomUserDetailsService.java
+++ b/Backend/src/main/java/com/back/global/security/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.back.global.security;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final MemberService memberService;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberService.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        return new SecurityUser(
+                member.getId(),
+                member.getUsername(),
+                "",
+                member.getNickname(),
+                member.getAuthorities()
+        );
+    }
+}

--- a/Backend/src/main/java/com/back/global/security/SecurityUser.java
+++ b/Backend/src/main/java/com/back/global/security/SecurityUser.java
@@ -1,0 +1,25 @@
+package com.back.global.security;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+
+@Getter
+public class SecurityUser extends User {
+    private final long id;
+    private final String name;
+
+    public SecurityUser(
+            long id,
+            String username,
+            String password,
+            String name,
+            Collection<? extends GrantedAuthority> authorities
+    ) {
+        super(username, password, authorities);
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/Backend/src/main/java/com/back/standard/util/Ut.java
+++ b/Backend/src/main/java/com/back/standard/util/Ut.java
@@ -1,0 +1,88 @@
+package com.back.standard.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ClaimsBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class Ut {
+    public static class jwt {
+        public static String toString(String secret, int expireSeconds, Map<String, Object> body) {
+            ClaimsBuilder claimsBuilder = Jwts.claims();
+
+            for (Map.Entry<String, Object> entry : body.entrySet()) {
+                claimsBuilder.add(entry.getKey(), entry.getValue());
+            }
+
+            Claims claims = claimsBuilder.build();
+
+            Date issuedAt = new Date();
+            Date expiration = new Date(issuedAt.getTime() + 1000L * expireSeconds);
+
+            Key secretKey = Keys.hmacShaKeyFor(secret.getBytes());
+
+            String jwt = Jwts.builder()
+                    .claims(claims)
+                    .issuedAt(issuedAt)
+                    .expiration(expiration)
+                    .signWith(secretKey)
+                    .compact();
+
+            return jwt;
+        }
+
+        public static boolean isValid(String secret, String jwtStr) {
+            SecretKey secretKey = Keys.hmacShaKeyFor(secret.getBytes());
+
+            try {
+                Jwts.parser()
+                        .verifyWith(secretKey)
+                        .build()
+                        .parseSignedClaims(jwtStr);
+            } catch (Exception e) {
+                return false;
+            }
+
+            return true;
+        }
+
+        public static Map<String, Object> payload(String secret, String jwtStr) {
+            SecretKey secretKey = Keys.hmacShaKeyFor(secret.getBytes());
+
+            try {
+                return new LinkedHashMap<>(
+                        Jwts.parser()
+                                .verifyWith(secretKey)
+                                .build()
+                                .parseSignedClaims(jwtStr)
+                                .getPayload()
+                );
+            } catch (Exception e) {
+                return null;
+            }
+        }
+    }
+
+    public static class json {
+        public static ObjectMapper objectMapper;
+
+        public static String toString(Object object) {
+            return toString(object, null);
+        }
+
+        public static String toString(Object object, String defaultValue) {
+            try {
+                return objectMapper.writeValueAsString(object);
+            } catch (Exception e) {
+                return defaultValue;
+            }
+        }
+    }
+}

--- a/Backend/src/main/resources/application.yml
+++ b/Backend/src/main/resources/application.yml
@@ -25,3 +25,9 @@ logging:
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE
     org.springframework.transaction.interceptor: TRACE
+
+custom:
+  jwt:
+    secretKey: abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789
+  accessToken:
+    expirationSeconds: "#{60*20}"

--- a/Backend/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/Backend/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -1,0 +1,232 @@
+package com.back.domain.member.member.controller;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberService;
+import jakarta.servlet.http.Cookie;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class MemberControllerTest {
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    @DisplayName("회원가입")
+    void t1() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/api/v1/members")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "username": "usernew",
+                                            "password": "1234",
+                                            "nickname": "무명"
+                                        }
+                                        """.stripIndent())
+                )
+                .andDo(print());
+
+        Member member = memberService.findByUsername("usernew").get();
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("join"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.resultCode").value("201-1"))
+                .andExpect(jsonPath("$.msg").value("%s님 환영합니다. 회원가입이 완료되었습니다.".formatted(member.getName())))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.id").value(member.getId()))
+                .andExpect(jsonPath("$.data.createDate").value(Matchers.startsWith(member.getCreateDate().toString().substring(0, 20))))
+                .andExpect(jsonPath("$.data.modifyDate").value(Matchers.startsWith(member.getModifyDate().toString().substring(0, 20))))
+                .andExpect(jsonPath("$.data.name").value(member.getName()));
+    }
+
+    @Test
+    @DisplayName("로그인")
+    void t2() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/api/v1/members/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "username": "user1",
+                                            "password": "1234"
+                                        }
+                                        """.stripIndent())
+                )
+                .andDo(print());
+
+        Member member = memberService.findByUsername("user1").get();
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("login"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.msg").value("%s님 환영합니다.".formatted(member.getNickname())))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.item").exists())
+                .andExpect(jsonPath("$.data.item.id").value(member.getId()))
+                .andExpect(jsonPath("$.data.item.createDate").value(Matchers.startsWith(member.getCreateDate().toString().substring(0, 20))))
+                .andExpect(jsonPath("$.data.item.modifyDate").value(Matchers.startsWith(member.getModifyDate().toString().substring(0, 20))))
+                .andExpect(jsonPath("$.data.item.name").value(member.getName()))
+                .andExpect(jsonPath("$.data.apiKey").value(member.getApiKey()))
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty());
+
+        resultActions.andExpect(
+                result -> {
+                    Cookie apiKeyCookie = result.getResponse().getCookie("apiKey");
+                    assertThat(apiKeyCookie.getValue()).isEqualTo(member.getApiKey());
+                    assertThat(apiKeyCookie.getPath()).isEqualTo("/");
+                    assertThat(apiKeyCookie.isHttpOnly()).isTrue();
+
+                    Cookie accessTokenCookie = result.getResponse().getCookie("accessToken");
+                    assertThat(accessTokenCookie.getValue()).isNotBlank();
+                    assertThat(accessTokenCookie.getPath()).isEqualTo("/");
+                    assertThat(apiKeyCookie.isHttpOnly()).isTrue();
+                }
+        );
+    }
+
+
+    @Test
+    @DisplayName("내 정보")
+    @WithUserDetails("user1")
+    void t3() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        get("/api/v1/members/me")
+                )
+                .andDo(print());
+
+        Member member = memberService.findByUsername("user1").get();
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(member.getId()))
+                .andExpect(jsonPath("$.createDate").value(Matchers.startsWith(member.getCreateDate().toString().substring(0, 20))))
+                .andExpect(jsonPath("$.modifyDate").value(Matchers.startsWith(member.getModifyDate().toString().substring(0, 20))))
+                .andExpect(jsonPath("$.name").value(member.getName()))
+                .andExpect(jsonPath("$.username").value(member.getUsername()));
+    }
+
+    @Test
+    @DisplayName("내 정보, with apiKey Cookie")
+    void t4() throws Exception {
+        Member actor = memberService.findByUsername("user1").get();
+        String actorApiKey = actor.getApiKey();
+
+        ResultActions resultActions = mvc
+                .perform(
+                        get("/api/v1/members/me")
+                                .cookie(new Cookie("apiKey", actorApiKey))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("me"))
+                .andExpect(status().isOk());
+    }
+
+
+    @Test
+    @DisplayName("로그아웃")
+    void t6() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        delete("/api/v1/members/logout")
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("logout"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.msg").value("로그아웃 되었습니다."))
+                .andExpect(result -> {
+                    Cookie apiKeyCookie = result.getResponse().getCookie("apiKey");
+                    assertThat(apiKeyCookie.getValue()).isEmpty();
+                    assertThat(apiKeyCookie.getMaxAge()).isEqualTo(0);
+                    assertThat(apiKeyCookie.getPath()).isEqualTo("/");
+                    assertThat(apiKeyCookie.isHttpOnly()).isTrue();
+                });
+    }
+
+    @Test
+    @DisplayName("엑세스 토큰이 만료되었거나 유효하지 않다면 apiKey를 통해서 재발급")
+    void t7() throws Exception {
+        Member actor = memberService.findByUsername("user1").get();
+        String actorApiKey = actor.getApiKey();
+
+        ResultActions resultActions = mvc
+                .perform(
+                        get("/api/v1/members/me")
+                                .header("Authorization", "Bearer " + actorApiKey + " wrong-access-token")
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("me"))
+                .andExpect(status().isOk());
+
+        resultActions.andExpect(
+                result -> {
+                    Cookie accessTokenCookie = result.getResponse().getCookie("accessToken");
+                    assertThat(accessTokenCookie.getValue()).isNotBlank();
+                    assertThat(accessTokenCookie.getPath()).isEqualTo("/");
+                    assertThat(accessTokenCookie.isHttpOnly()).isTrue();
+
+                    String headerAuthorization = result.getResponse().getHeader("Authorization");
+                    assertThat(headerAuthorization).isNotBlank();
+
+                    assertThat(headerAuthorization).isEqualTo(accessTokenCookie.getValue());
+                }
+        );
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더가 Bearer 형식이 아닐 때 오류")
+    void t8() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        get("/api/v1/members/me")
+                                .header("Authorization", "key")
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("401-2"))
+                .andExpect(jsonPath("$.msg").value("Authorization 헤더가 Bearer 형식이 아닙니다."));
+    }
+}

--- a/Backend/src/test/java/com/back/domain/member/member/service/AuthTokenServiceTest.java
+++ b/Backend/src/test/java/com/back/domain/member/member/service/AuthTokenServiceTest.java
@@ -1,0 +1,133 @@
+package com.back.domain.member.member.service;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.standard.util.Ut;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class AuthTokenServiceTest {
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private AuthTokenService authTokenService;
+
+    @Value("${custom.jwt.secretKey}")
+    private String jwtSecretKey;
+
+    @Value("${custom.accessToken.expirationSeconds}")
+    private int accessTokenExpirationSeconds;
+
+    @Test
+    @DisplayName("authTokenService 서비스가 존재한다.")
+    void t1() {
+        assertThat(authTokenService).isNotNull();
+    }
+
+    @Test
+    @DisplayName("jjwt 최신 방식으로 JWT 생성, {name=\"Paul\", age=23}")
+    void t2() {
+        // 토큰 만료기간: 1년
+        long expireMillis = 1000L * accessTokenExpirationSeconds;
+
+        byte[] keyBytes = jwtSecretKey.getBytes(StandardCharsets.UTF_8);
+        SecretKey secretKey = Keys.hmacShaKeyFor(keyBytes);
+
+        // 발행 시간과 만료 시간 설정
+        Date issuedAt = new Date();
+        Date expiration = new Date(issuedAt.getTime() + expireMillis);
+
+        Map<String, Object> payload = Map.of(
+                "name", "Paul",
+                "age", 23
+        );
+
+        String jwt = Jwts.builder()
+                .claims(payload) // 내용
+                .issuedAt(issuedAt) // 생성날짜
+                .expiration(expiration) // 만료날짜
+                .signWith(secretKey) // 키 서명
+                .compact();
+
+        assertThat(jwt).isNotBlank();
+
+        System.out.println("jwt = " + jwt);
+
+        // 키가 유효한지 테스트
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(jwt)
+                .getPayload();
+
+        Map<String, Object> parsedPayload = new LinkedHashMap<>(claims);
+
+        assertThat(parsedPayload)
+                .containsAllEntriesOf(payload);
+    }
+
+    @Test
+    @DisplayName("Ut.jwt.toString 를 통해서 JWT 생성, {name=\"Paul\", age=23}")
+    void t3() {
+        Map<String, Object> payload = Map.of("name", "Paul", "age", 23);
+
+        String jwt = Ut.jwt.toString(
+                jwtSecretKey,
+                accessTokenExpirationSeconds,
+                payload
+        );
+
+        assertThat(jwt).isNotBlank();
+
+        assertThat(
+                Ut.jwt.isValid(jwtSecretKey, jwt)
+        )
+                .isTrue();
+
+        Map<String, Object> parsedPayload = Ut.jwt.payload(jwtSecretKey, jwt);
+
+        assertThat(parsedPayload).containsAllEntriesOf(payload);
+    }
+
+    @Test
+    @DisplayName("authTokenService.genAccessToken(member);")
+    void t4() {
+        Member memberUser1 = memberService.findByUsername("user1").get();
+
+        String accessToken = authTokenService.genAccessToken(memberUser1);
+
+        assertThat(accessToken).isNotBlank();
+
+        System.out.println("accessToken = " + accessToken);
+
+        Map<String, Object> parsedPayload = authTokenService.payload(accessToken);
+
+        assertThat(parsedPayload)
+                .containsAllEntriesOf(
+                        Map.of(
+                                "id", memberUser1.getId(),
+                                "username", memberUser1.getUsername(),
+                                "name", memberUser1.getName()
+                        )
+                );
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
- 로그인, 로그아웃 기능을 구현했습니다.
- 헤더, 토큰에 apiKey, access Token 추가

## 🔗 관련 이슈
- close #37

## 🛠 변경 사항
- [ ] 기능 구현

## 🧪 테스트 내용
- [ ] 로컬 테스트 완료
- [ ] Postman 테스트
- [ ] 테스트 코드 작성

## 📎 참고 사항
